### PR TITLE
Fix GCC 11 compilation

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -26,6 +26,7 @@
 #include <dirent.h>
 #include <sys/uio.h>
 #include <iconv.h>
+#include <limits>
 
 memory::pattern::pattern() : mem_location(-1) {
 }


### PR DESCRIPTION
Per https://gcc.gnu.org/gcc-11/porting_to.html :

> Header dependency changes
> Some C++ Standard Library headers have been changed to no longer include
> other headers that they do need to depend on.
> * <limits> (for std::numeric_limits)